### PR TITLE
Request for change requisition generation

### DIFF
--- a/apps/core/lib/core/service_requests/service_request.ex
+++ b/apps/core/lib/core/service_requests/service_request.ex
@@ -263,11 +263,11 @@ defmodule Core.ServiceRequest do
            {:encounter, Encounters.get_by_id(patient_id_hash, to_string(encounter_id))},
          {:ok, number} <-
            @worker.run("number_generator", NumberGenerator.Rpc, :number, [
-             "episode",
-             to_string(encounter.episode.identifier.value),
+             "encounter",
+             to_string(encounter.identifier.value),
              user_id
            ]) do
-      put_change(changeset, :requisition, Encryptor.encrypt(number))
+      put_change(changeset, :requisition, number)
     else
       _ -> add_error(changeset, :requisition, "Failed to generate requisition number")
     end


### PR DESCRIPTION
1. I think requisition should be linked to encounter, not episode. Because we patient will receive the same requisition number for one episode. If it's an episode of chronic disease, then it will be one requisition number forever.

2. Encryption of requisition number in CDB prevent fraud-detection in NHSU